### PR TITLE
add ability to filter search results by a desired baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ vignettes/*.pdf
 
 ## ignore backup files
 *~
+.Rproj.user
+
+# Ignore my project so it doesn't get into the pull reqs
+.canadaHCD.Rproj

--- a/.gitignore
+++ b/.gitignore
@@ -1,26 +1,19 @@
 # History files
 .Rhistory
 .Rapp.history
-
 # Session Data files
 .RData
-
 # Example code in package build process
 *-Ex.R
-
 # RStudio files
 .Rproj.user/
-
 # produced vignettes
 vignettes/*.html
 vignettes/*.pdf
-
 # OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
 .httr-oauth
-
 ## ignore backup files
 *~
 .Rproj.user
-
 # Ignore my project so it doesn't get into the pull reqs
-.canadaHCD.Rproj
+canadaHCD.Rproj

--- a/R/find_station.R
+++ b/R/find_station.R
@@ -1,8 +1,11 @@
 ##' @title Find a Historical Climate Data station
 ##'
-##' @description Search for stations in the Historical Climate Data inventory by name.
+##' @description Search for stations in the Historical Climate Data inventory by name, with the option to filter by available data.
 ##'
 ##' @param name character; character string or a regular expression to be matched against known station names. See \code{\link{grep}} for details.
+##' @param ignore.case logical; by default the search for station names is not case-sensitive.
+##' @param baseline vector; a vector with a start and end year for a desired baseline. It is not used by default.
+##' @param type character; only used if a baseline is specified. Defaults to "hourly".
 ##' @param ignore.case logical; by default the search for station names is not case-sensitive.
 ##' @param ... Additional arguments passed to \code{\link{grep}}.
 ##'
@@ -11,15 +14,33 @@
 ##' @export
 ##'
 ##' @author Gavin L. Simpson
+##' @author Conor I. Anderson
 ##'
 ##' @examples
 ##' find_station("Regina")
 ##'
-##' find_station("Yellowknife")
-`find_station` <- function(name = NULL, ignore.case = TRUE, ...) {
+##' find_station("Yellowknife", baseline = c(1971, 2000), type = "hourly")
+`find_station` <- function(name = NULL, baseline = NULL, type = "hourly", ignore.case = TRUE, ...) {
     take <- grep(name, station_data$Name, ignore.case = ignore.case, ...)
-    vars_wanted <- c("Name", "Province", "StationID", "LatitudeDD", "LongitudeDD")
+    data_vars <- NULL
+    if (!is.null(baseline)) {
+      if (length(baseline) != 2 | baseline[1] > baseline[2]) stop("error: check baseline format")
+      if (type == "hourly") data_vars <- c("HourlyFirstYr", "HourlyLastYr")
+      if (type == "daily") data_vars <- c("DailyFirstYr", "DailyLastYr")
+      if (type == "monthly") data_vars <- c("MonthlyFirstYr", "MonthlyLastYr")
+    } 
+    vars_wanted <- c("Name", "Province", "StationID", "LatitudeDD", "LongitudeDD", data_vars)
     df <- station_data[take, vars_wanted]
     class(df) <- c("hcd_station_list", class(df))
+    if (!is.null(baseline)) {
+      i = 1
+      index = NULL
+      while (i <= nrow(df)) {
+        if (is.na(df[i,6]) | df[i,6] > baseline[1]) index <- c(index, i)
+        else if (is.na(df[i,7]) | df[i,7] < baseline[2]) index <- c(index, i)
+        i <- i+1
+      }
+      df <- df[-index,]
+    }
     df
 }

--- a/R/find_station.R
+++ b/R/find_station.R
@@ -6,7 +6,6 @@
 ##' @param ignore.case logical; by default the search for station names is not case-sensitive.
 ##' @param baseline vector; a vector with a start and end year for a desired baseline. It is not used by default.
 ##' @param type character; only used if a baseline is specified. Defaults to "hourly".
-##' @param ignore.case logical; by default the search for station names is not case-sensitive.
 ##' @param ... Additional arguments passed to \code{\link{grep}}.
 ##'
 ##' @return An object of class \code{"hcd_station_list"}, which is a \code{"tbl_df"}, containing details of any matching HCD stations.
@@ -18,8 +17,8 @@
 ##'
 ##' @examples
 ##' find_station("Regina")
-##'
 ##' find_station("Yellowknife", baseline = c(1971, 2000), type = "hourly")
+
 `find_station` <- function(name = NULL, baseline = NULL, type = "hourly", ignore.case = TRUE, ...) {
     take <- grep(name, station_data$Name, ignore.case = ignore.case, ...)
     data_vars <- NULL

--- a/man/find_station.Rd
+++ b/man/find_station.Rd
@@ -17,8 +17,6 @@ find_station(name = NULL, baseline = NULL, type = "hourly",
 \item{ignore.case}{logical; by default the search for station names is not case-sensitive.}
 
 \item{...}{Additional arguments passed to \code{\link{grep}}.}
-
-\item{ignore.case}{logical; by default the search for station names is not case-sensitive.}
 }
 \value{
 An object of class \code{"hcd_station_list"}, which is a \code{"tbl_df"}, containing details of any matching HCD stations.
@@ -28,7 +26,6 @@ Search for stations in the Historical Climate Data inventory by name, with the o
 }
 \examples{
 find_station("Regina")
-
 find_station("Yellowknife", baseline = c(1971, 2000), type = "hourly")
 }
 \author{

--- a/man/find_station.Rd
+++ b/man/find_station.Rd
@@ -4,27 +4,36 @@
 \alias{find_station}
 \title{Find a Historical Climate Data station}
 \usage{
-find_station(name = NULL, ignore.case = TRUE, ...)
+find_station(name = NULL, baseline = NULL, type = "hourly",
+  ignore.case = TRUE, ...)
 }
 \arguments{
 \item{name}{character; character string or a regular expression to be matched against known station names. See \code{\link{grep}} for details.}
 
+\item{baseline}{vector; a vector with a start and end year for a desired baseline. It is not used by default.}
+
+\item{type}{character; only used if a baseline is specified. Defaults to "hourly".}
+
 \item{ignore.case}{logical; by default the search for station names is not case-sensitive.}
 
 \item{...}{Additional arguments passed to \code{\link{grep}}.}
+
+\item{ignore.case}{logical; by default the search for station names is not case-sensitive.}
 }
 \value{
 An object of class \code{"hcd_station_list"}, which is a \code{"tbl_df"}, containing details of any matching HCD stations.
 }
 \description{
-Search for stations in the Historical Climate Data inventory by name.
+Search for stations in the Historical Climate Data inventory by name, with the option to filter by available data.
 }
 \examples{
 find_station("Regina")
 
-find_station("Yellowknife")
+find_station("Yellowknife", baseline = c(1971, 2000), type = "hourly")
 }
 \author{
 Gavin L. Simpson
+
+Conor I. Anderson
 }
 


### PR DESCRIPTION
If interested, I have added a few lines of code that make it possible to filter the search results provided by the find_stations function by a desired baseline. Examples provided in the documentation. 
