### PR TITLE
Repair yearmon after bind_rows.

### DIFF
--- a/R/collapse_hcd.R
+++ b/R/collapse_hcd.R
@@ -12,7 +12,9 @@
 ##' @importFrom tibble add_column
 `collapse_hcd` <- function(l, station) {
     nr <- vapply(l, NROW, integer(1L))
+    if (class(l$Date) == "yearmon") fix = TRUE
     l <- bind_rows(l)
+    if (fix) l$Date <- as.yearmon(l$Date)
     l <- add_column(l, Station = rep(station, times = nr),
                     .before = 1)
     l

--- a/R/collapse_hcd.R
+++ b/R/collapse_hcd.R
@@ -12,7 +12,7 @@
 ##' @importFrom tibble add_column
 `collapse_hcd` <- function(l, station) {
     nr <- vapply(l, NROW, integer(1L))
-    fixym <- class(l$Date) == "yearmon"
+    fixym <- class(l[[1]]$Date) == "yearmon"
     l <- bind_rows(l)
     if (fixym) l$Date <- as.yearmon(l$Date)
     l <- add_column(l, Station = rep(station, times = nr),

--- a/R/collapse_hcd.R
+++ b/R/collapse_hcd.R
@@ -12,9 +12,9 @@
 ##' @importFrom tibble add_column
 `collapse_hcd` <- function(l, station) {
     nr <- vapply(l, NROW, integer(1L))
-    if (class(l$Date) == "yearmon") fix = TRUE
+    fixym <- class(l$Date) == "yearmon"
     l <- bind_rows(l)
-    if (fix) l$Date <- as.yearmon(l$Date)
+    if (fixym) l$Date <- as.yearmon(l$Date)
     l <- add_column(l, Station = rep(station, times = nr),
                     .before = 1)
     l


### PR DESCRIPTION
(Hopefully temporary) workaround to restore the yearmon column after bind_rows in collapse_hcd. Fixes #13.