### PR TITLE
Only close(pb) when progress is TRUE.

### DIFF
--- a/R/process_downloads.R
+++ b/R/process_downloads.R
@@ -4,8 +4,8 @@
     sdata <- vector(mode = "list", length = nurls)
     if (isTRUE(progress)) {
         pb <- txtProgressBar(min = 0, max = nurls, style = 3)
+        on.exit(close(pb))
     }
-    on.exit(if (isTRUE(progress)) close(pb))
     for (i in seq_along(sdata)) {
         sdata[[i]] <- get_hcd_from_url(urls[i], ...)
         if (isTRUE(progress)) {

--- a/R/process_downloads.R
+++ b/R/process_downloads.R
@@ -5,7 +5,7 @@
     if (isTRUE(progress)) {
         pb <- txtProgressBar(min = 0, max = nurls, style = 3)
     }
-    on.exit(close(pb))
+    on.exit(if (isTRUE(progress)) close(pb))
     for (i in seq_along(sdata)) {
         sdata[[i]] <- get_hcd_from_url(urls[i], ...)
         if (isTRUE(progress)) {


### PR DESCRIPTION
Currenly, hcd_*ly commands fail with `Error in close(pb) : object 'pb' not found` when `progress = FALSE`.